### PR TITLE
Force Python buildpack in app.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This project is a concrete integration of the [django-accounting](https://github.com/dulaccc/django-accounting) application.
 It is ready to be deployed on Heroku, but you can deploy on which provider you want.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/dulaccc/Accountant)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 
 ## Under the hood

--- a/app.json
+++ b/app.json
@@ -14,6 +14,7 @@
     "newrelic:wayne"
   ],
   "env": {
+    "BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-python",
     "DJANGO_SETTINGS_MODULE": "accountant.settings.prod",
     "SECRET_KEY": {
       "description": "This gets generated",


### PR DESCRIPTION
Deploy using the button fails otherwise - the `package.json` causes Heroku to detect the app as Node.js.